### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/backend/src/utils/cloudinary.js
+++ b/backend/src/utils/cloudinary.js
@@ -73,8 +73,13 @@ export const uploadAvatar = async (imagePath) => {
 		};
 	} catch (error) {
 		// Delete the local file if upload fails
-		if (fs.existsSync(imagePath)) {
-			fs.unlinkSync(imagePath);
+		try {
+			const resolvedPath = fs.realpathSync(path.resolve(imagePath));
+			if (resolvedPath.startsWith(UPLOADS_ROOT) && fs.existsSync(resolvedPath)) {
+				fs.unlinkSync(resolvedPath);
+			}
+		} catch (validationError) {
+			console.error('Error validating file path during cleanup:', validationError);
 		}
 		throw error;
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/HelderBalbino/BartendersHub/security/code-scanning/11](https://github.com/HelderBalbino/BartendersHub/security/code-scanning/11)

To fix the issue, the error-handling block in the `uploadAvatar` function should validate the `imagePath` before using it in file operations. Specifically, the same validation logic used in the main function should be applied to ensure the path is resolved and checked against the safe root directory (`UPLOADS_ROOT`). This will prevent malicious paths from being used in file operations.

**Steps to implement the fix:**
1. Add the path resolution and validation logic to the error-handling block.
2. Ensure that the `fs.unlinkSync` operation is only performed if the path is valid.
3. Avoid duplicating code by extracting the validation logic into a helper function if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
